### PR TITLE
PFM-ISSUE-11470 - Exclude e2e from main ci if PERCY_TOKEN is not provided

### DIFF
--- a/.github/workflow-templates/fe/fe-main.yml
+++ b/.github/workflow-templates/fe/fe-main.yml
@@ -20,8 +20,6 @@ jobs:
   e2e-tests:
     needs: install-deps
     uses: collaborationFactory/github-actions/.github/workflows/fe-e2e.yml@master
-    # E2E tests should run in the default branch only if Percy is being used
-    if: ${{ secrets.PERCY_TOKEN }}
     with:
       GHA_REF: ''
       GHA_BASE: ${{ github.event.before }}

--- a/.github/workflows/fe-e2e.yml
+++ b/.github/workflows/fe-e2e.yml
@@ -24,16 +24,23 @@ jobs:
     env:
       jobCount: 4
     steps:
+      - name: Check Percy Token
+        id: percyToken
+        run: echo '::set-output name=value::${{secrets.PERCY_TOKEN}}'
+
       - uses: actions/checkout@v2
+        if: steps.percyToken.outputs.value
         with:
           ref: ${{ inputs.GHA_REF }}
           fetch-depth: 0
 
       - uses: actions/setup-node@v1
+        if: steps.percyToken.outputs.value
         with:
           node-version: '14'
 
       - name: Cache Node Modules
+        if: steps.percyToken.outputs.value
         id: npm-cache
         uses: actions/cache@v2
         with:
@@ -41,9 +48,11 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install Cypress Binary
+        if: steps.percyToken.outputs.value
         run: npx cypress install
 
       - name: Affected Regression Tests
+        if: steps.percyToken.outputs.value
         uses: collaborationFactory/github-actions/.github/actions/run-many@master
         with:
           target: ${{ matrix.target }}


### PR DESCRIPTION
Resolves [PFM-ISSUE-11470](https://base.cplace.io/pages/tlh4xwhmpmt68mpphec0o40ge/PFM-ISSUE-11470-Exclude-main-ci-if-PERCY-TOKEN-is-not-provided#id_wsrqdlqi9cus7fztqfsfa3gnz=cf.cplace.cfactoryPlatform.overview)

`changelog: Frontend-Scripts: Excluded e2e from main Ci if PERCY_TOKEN is not provided [PFM-ISSUE-11470, PR github-actions#22]`

In issue:

- [ ] Documented Breaking changes?

Criticality:

- [ ] Contains migration steps?
