### PR TITLE
PFM-ISSUE-11791 - Fix frontend licenses GHA

### DIFF
--- a/.github/workflows/fe-licenses.yml
+++ b/.github/workflows/fe-licenses.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run Diff
         continue-on-error: true
-        run: diff -a --suppress-common-lines -y ./foss-list.json ${{ inputs.FOSS_DIST }}/foss-list.json
+        run: diff -a --suppress-common-lines -y ./cplace-foss-list.json ${{ inputs.FOSS_DIST }}/cplace-foss-list.json
 
       - name: Read fossTmp
         id: readFossTmp


### PR DESCRIPTION
Resolves [PFM-ISSUE-11791](https://base.cplace.io/pages/oawq0t5w08g32tb0r13ssnatd/PFM-ISSUE-11791-Fix-frontend-licenses-GHA#id_wsrqdlqi9cus7fztqfsfa3gnz=cf.cplace.cfactoryPlatform.overview)

`changelog: Frontend-Core: Fixed wrong FOSS file name used by frontend licenses GHA [PFM-ISSUE-11791, PR github-actions#34]`

In issue:

- [ ] Documented Breaking changes?

Criticality:

- [ ] Contains migration steps?
