### PR TITLE
PFM-TASK-3347 removed deletion of snapshot versions

### DIFF
--- a/tools/scripts/artifacts/artifacts-handler.ts
+++ b/tools/scripts/artifacts/artifacts-handler.ts
@@ -130,9 +130,6 @@ export class ArtifactsHandler {
           project.build();
           project.writeNPMRCInDist(this.jfrogCredentials, this.scope);
           project.setVersionOrGeneratePackageJsonInDist(this.currentVersion);
-          // delete existing artifact in case it is a snapshot that should be replaced
-          if (this.task === TASK.MAIN_SNAPSHOT)
-            await project.deleteSnapshots(this.jfrogCredentials);
           if (this.task === TASK.PR_SNAPSHOT)
             await project.deleteArtifact(
               this.jfrogCredentials,


### PR DESCRIPTION
Resolves [PFM-TASK-3347](https://base.cplace.io/pages/xx4kqebstjuz3uwefbbu9h83c/PFM-TASK-3347-no-longer-overwrite-snapshots-in-jfrog-but-create-a-new-one)

`changelog: Frontend-Core:  removed deletion of snapshot versions [PFM-TASK-3347, PR github-actions#38]`

In issue:

- [x] Documented Breaking changes?

