### PR TITLE
PFM-ISSUE-25767 - Cypress videos as github artifacts

### DIFF
--- a/.github/workflows/fe-e2e.yml
+++ b/.github/workflows/fe-e2e.yml
@@ -54,3 +54,17 @@ jobs:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           PERCY_PARTIAL_BUILD: 1
           DEV_STORIES: true
+
+      - name: Upload E2E Videos
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-videos
+          path: |
+            dist/cypress/apps/**/videos/
+
+      - name: Upload A11Y Reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: a11y-reports
+          path: |
+            dist/cypress/apps/**/a11y/html/


### PR DESCRIPTION
Resolves [PFM-ISSUE-25767](https://base.cplace.io/pages/2rkb6jfetlx2y58qa22dqvbvg/PFM-ISSUE-25767-Cypress-videos-as-github-artifacts#id_wsrqdlqi9cus7fztqfsfa3gnz=newOverview)

`changelog: Frontend Build: Exposed Cypress videos and A11Y reports as artifacts [PFM-ISSUE-25767, PR github-actions#65]`

In issue:

- [ ] Documented Breaking changes?

Criticality:

- [ ] Contains migration steps?
