### PR TITLE
Update fe-build.yml

### DIFF
--- a/.github/workflows/fe-build.yml
+++ b/.github/workflows/fe-build.yml
@@ -19,6 +19,7 @@ jobs:
         jobIndex: [1, 2]
     env:
       jobCount: 2
+      NODE_OPTIONS: --max-old-space-size=4096
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
increased memory for build jobs

[PFM-ISSUE-27110](https://base.cplace.io/pages/9r0yntteg5bcazl4eealakovj/PFM-ISSUE-27110-Github-Action-fails-with-Out-of-Memory#id_wsrqdlqi9cus7fztqfsfa3gnz=newOverview)