### PR TITLE
PFM-TASK-5024: Disable parallel when running e2e tests

### DIFF
--- a/tools/scripts/run-many/run-many.ts
+++ b/tools/scripts/run-many/run-many.ts
@@ -37,7 +37,7 @@ function main() {
   const projects = getAffectedProjects(target, jobIndex, jobCount, base, ref);
 
   const runManyProjectsCmd = `./node_modules/.bin/nx run-many --targets=${target} --projects=${projects}`;
-  let cmd = `${runManyProjectsCmd} --parallel --prod`;
+  let cmd = `${runManyProjectsCmd} --parallel=false --prod`;
 
   if (target.includes('e2e')) {
     cmd = getE2ECommand(cmd, base);


### PR DESCRIPTION
Resolves [PFM-TASK-5024](https://base.cplace.io/pages/kooqhgw4fs2r65561r3rlhfj5/PFM-TASK-5024-Disable-parallel-when-running-e2e-tests?highlightedEntityUid=page%2Fkooqhgw4fs2r65561r3rlhfj5)

`changelog: Frontend-Core: [PFM-TASK-5024] Fix: disable running e2e tests in parallel within the same job [PR github-actions#72]`

**Developer Checklist:**

- [x] Updated documentation if needed
- [x] Created Changelog according
  to [Guidelines](https://docs.cplace.io/frontend-applications/22-3/guides/pr-guideline/)
