### PR TITLE
PFM-TASK-5033: Print more error information out when e2e fails

### DIFF
--- a/tools/scripts/run-many/run-many.ts
+++ b/tools/scripts/run-many/run-many.ts
@@ -14,7 +14,11 @@ function runCommand(command: string): void {
     const output = execSync(command, { maxBuffer: 1024 * 1024 * 1024 });
     core.info(output.toString())
   } catch (error) {
-    core.info(error.stdout.toString())
+    core.info(error.stdout.toString());
+    core.error(error.stderr.toString());
+    core.error(`Error message: ${error.message}`);
+    core.error(`Error name: ${error.name}`);
+    core.error(`Stacktrace:\n${error.stack}`);
     core.setFailed(error);
   }
 }


### PR DESCRIPTION
Resolves [PFM-TASK-5033](https://base.cplace.io/pages/fdaggignz02y23xs0dhyszrap/PFM-TASK-5033-Print-more-error-information-out-when-e2e-fails?highlightedEntityUid=page%2Ffdaggignz02y23xs0dhyszrap)

`changelog: Frontend-Core: [PFM-TASK-5033] Fix: print more error information when e2e fails [PR github-actions#PR-number]`

**Developer Checklist:**

- [x] Updated documentation if needed
- [x] Created Changelog according
  to [Guidelines](https://docs.cplace.io/frontend-applications/22-3/guides/pr-guideline/)
