### PR TITLE
PFM-TASK-5418 - Rework hard coded jfrog url in the delete pr snapshot workflow

### DIFF
--- a/.github/workflows/fe-pr-snapshot.yml
+++ b/.github/workflows/fe-pr-snapshot.yml
@@ -6,9 +6,6 @@ on:
       GHA_BASE:
         type: string
         required: true
-      NPM_REGISTRY:
-        type: string
-        required: false
     secrets:
       JFROG_BASE64_TOKEN:
         required: true
@@ -18,6 +15,8 @@ on:
         required: true
       DOT_NPMRC:
         required: true
+      NPM_REGISTRY:
+        required: false
 
 jobs:
   publish-pr-snapshot:
@@ -50,12 +49,12 @@ jobs:
         run: npm ci
 
       - name: Build and Push to Jfrog NPM Registry
-        uses: collaborationFactory/github-actions/.github/actions/artifacts@master
+        uses: collaborationFactory/github-actions/.github/actions/artifacts@fix/PFM-ISSUE-28366-Github-unable-to-publish-only-libs-without
         env:
           JFROG_BASE64_TOKEN: ${{ secrets.JFROG_BASE64_TOKEN }}
           JFROG_URL: ${{ secrets.JFROG_URL }}
           JFROG_USER: ${{ secrets.JFROG_USER }}
-          NPM_REGISTRY: ${{ inputs.NPM_REGISTRY }}
+          NPM_REGISTRY: ${{ secrets.NPM_REGISTRY }}
           BASE: ${{ inputs.GHA_BASE }}
           PR_NUMBER: ${{ github.event.number }}
 

--- a/.github/workflows/fe-pr-snapshot.yml
+++ b/.github/workflows/fe-pr-snapshot.yml
@@ -6,6 +6,9 @@ on:
       GHA_BASE:
         type: string
         required: true
+      NPM_REGISTRY:
+        type: string
+        required: false
     secrets:
       JFROG_BASE64_TOKEN:
         required: true
@@ -13,8 +16,6 @@ on:
         required: true
       JFROG_USER:
         required: true
-      NPM_REGISTRY:
-        required: false
       DOT_NPMRC:
         required: true
 
@@ -54,7 +55,7 @@ jobs:
           JFROG_BASE64_TOKEN: ${{ secrets.JFROG_BASE64_TOKEN }}
           JFROG_URL: ${{ secrets.JFROG_URL }}
           JFROG_USER: ${{ secrets.JFROG_USER }}
-          NPM_REGISTRY: ${{ secrets.NPM_REGISTRY }}
+          NPM_REGISTRY: ${{ inputs.NPM_REGISTRY }}
           BASE: ${{ inputs.GHA_BASE }}
           PR_NUMBER: ${{ github.event.number }}
 

--- a/.github/workflows/fe-pr-snapshot.yml
+++ b/.github/workflows/fe-pr-snapshot.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm ci
 
       - name: Build and Push to Jfrog NPM Registry
-        uses: collaborationFactory/github-actions/.github/actions/artifacts@fix/PFM-ISSUE-28366-Github-unable-to-publish-only-libs-without
+        uses: collaborationFactory/github-actions/.github/actions/artifacts@master
         env:
           JFROG_BASE64_TOKEN: ${{ secrets.JFROG_BASE64_TOKEN }}
           JFROG_URL: ${{ secrets.JFROG_URL }}

--- a/.github/workflows/fe-pr-snapshot.yml
+++ b/.github/workflows/fe-pr-snapshot.yml
@@ -52,7 +52,6 @@ jobs:
           JFROG_BASE64_TOKEN: ${{ secrets.JFROG_BASE64_TOKEN }}
           JFROG_URL: ${{ secrets.JFROG_URL }}
           JFROG_USER: ${{ secrets.JFROG_USER }}
-          NPM_REGISTRY: ${{ secrets.NPM_REGISTRY }}
           BASE: ${{ inputs.GHA_BASE }}
           PR_NUMBER: ${{ github.event.number }}
 

--- a/.github/workflows/fe-pr-snapshot.yml
+++ b/.github/workflows/fe-pr-snapshot.yml
@@ -52,6 +52,7 @@ jobs:
           JFROG_BASE64_TOKEN: ${{ secrets.JFROG_BASE64_TOKEN }}
           JFROG_URL: ${{ secrets.JFROG_URL }}
           JFROG_USER: ${{ secrets.JFROG_USER }}
+          NPM_REGISTRY: ${{ secrets.NPM_REGISTRY }}
           BASE: ${{ inputs.GHA_BASE }}
           PR_NUMBER: ${{ github.event.number }}
 

--- a/.github/workflows/fe-pr-snapshot.yml
+++ b/.github/workflows/fe-pr-snapshot.yml
@@ -13,6 +13,8 @@ on:
         required: true
       JFROG_USER:
         required: true
+      NPM_REGISTRY:
+        required: false
       DOT_NPMRC:
         required: true
 
@@ -52,6 +54,7 @@ jobs:
           JFROG_BASE64_TOKEN: ${{ secrets.JFROG_BASE64_TOKEN }}
           JFROG_URL: ${{ secrets.JFROG_URL }}
           JFROG_USER: ${{ secrets.JFROG_USER }}
+          NPM_REGISTRY: ${{ secrets.NPM_REGISTRY }}
           BASE: ${{ inputs.GHA_BASE }}
           PR_NUMBER: ${{ github.event.number }}
 

--- a/.github/workflows/fe-pr-snapshot.yml
+++ b/.github/workflows/fe-pr-snapshot.yml
@@ -47,12 +47,11 @@ jobs:
         run: npm ci
 
       - name: Build and Push to Jfrog NPM Registry
-        uses: collaborationFactory/github-actions/.github/actions/artifacts@fix/PFM-ISSUE-28366-Github-unable-to-publish-only-libs-without
+        uses: collaborationFactory/github-actions/.github/actions/artifacts@master
         env:
           JFROG_BASE64_TOKEN: ${{ secrets.JFROG_BASE64_TOKEN }}
           JFROG_URL: ${{ secrets.JFROG_URL }}
           JFROG_USER: ${{ secrets.JFROG_USER }}
-          NPM_REGISTRY: ${{ secrets.NPM_REGISTRY }}
           BASE: ${{ inputs.GHA_BASE }}
           PR_NUMBER: ${{ github.event.number }}
 

--- a/.github/workflows/fe-pr-snapshot.yml
+++ b/.github/workflows/fe-pr-snapshot.yml
@@ -15,8 +15,6 @@ on:
         required: true
       DOT_NPMRC:
         required: true
-      NPM_REGISTRY:
-        required: false
 
 jobs:
   publish-pr-snapshot:

--- a/.github/workflows/fe-pr-snapshot.yml
+++ b/.github/workflows/fe-pr-snapshot.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm ci
 
       - name: Build and Push to Jfrog NPM Registry
-        uses: collaborationFactory/github-actions/.github/actions/artifacts@master
+        uses: collaborationFactory/github-actions/.github/actions/artifacts@fix/PFM-ISSUE-28366-Github-unable-to-publish-only-libs-without
         env:
           JFROG_BASE64_TOKEN: ${{ secrets.JFROG_BASE64_TOKEN }}
           JFROG_URL: ${{ secrets.JFROG_URL }}

--- a/tools/scripts/artifacts/artifacts-handler.test.ts
+++ b/tools/scripts/artifacts/artifacts-handler.test.ts
@@ -18,6 +18,7 @@ import {
   npmrc,
   packageJsonLib2,
 } from './test-data';
+import { sep } from 'node:path';
 
 export const SNAPSHOT_VERSION = ArtifactsHandler.SNAPSHOT_VERSION + '-SNAPSHOT';
 
@@ -150,16 +151,16 @@ test('can create and overwrite Snapshots in main branch', async () => {
   expect(artifactHandler.projects[2].name).toBe(lib1);
   expect(artifactHandler.projects[3].name).toBe(lib2);
   expect(artifactHandler.projects[0].getPathToProjectInDist()).toContain(
-    `dist/apps/my/${app1}`
+    `dist/apps/my/${app1}`.replace(/\//g, sep)
   );
   expect(artifactHandler.projects[1].getPathToProjectInDist()).toContain(
-    `dist/apps/${app2}`
+    `dist/apps/${app2}`.replace(/\//g, sep)
   );
   expect(artifactHandler.projects[2].getPathToProjectInDist()).toContain(
-    `dist/libs/${lib1}`
+    `dist/libs/${lib1}`.replace(/\//g, sep)
   );
   expect(artifactHandler.projects[3].getPathToProjectInDist()).toContain(
-    `dist/libs/${lib2}`
+    `dist/libs/${lib2}`.replace(/\//g, sep)
   );
   expect(artifactHandler.projects[0].npmrcContent).toBe(npmrc);
   expect(artifactHandler.projects[1].npmrcContent).toBe(npmrc);

--- a/tools/scripts/artifacts/artifacts-handler.ts
+++ b/tools/scripts/artifacts/artifacts-handler.ts
@@ -14,7 +14,7 @@ export enum TASK {
 export class ArtifactsHandler {
   public static readonly SNAPSHOT_VERSION = '0.0.0';
   public static readonly SNAPSHOT = 'SNAPSHOT';
-    'https://cplace.jfrog.io/artifactory/api/npm/cplace-npm-local/';
+    'https://cplace.jfrog.io/artifactory/api/npm/cplace-assets-npm/';
   public static readonly RELEASE_BRANCH_PREFIX = 'release/';
   // semver regex from https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39
   public static readonly SEMVER_REGEX =

--- a/tools/scripts/artifacts/artifacts-handler.ts
+++ b/tools/scripts/artifacts/artifacts-handler.ts
@@ -14,7 +14,6 @@ export enum TASK {
 export class ArtifactsHandler {
   public static readonly SNAPSHOT_VERSION = '0.0.0';
   public static readonly SNAPSHOT = 'SNAPSHOT';
-    'https://cplace.jfrog.io/artifactory/api/npm/cplace-assets-npm/';
   public static readonly RELEASE_BRANCH_PREFIX = 'release/';
   // semver regex from https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39
   public static readonly SEMVER_REGEX =

--- a/tools/scripts/artifacts/artifacts-handler.ts
+++ b/tools/scripts/artifacts/artifacts-handler.ts
@@ -125,10 +125,10 @@ export class ArtifactsHandler {
           project.copyFossList();
           project.setVersionOrGeneratePackageJsonInDist(this.currentVersion, this.jfrogCredentials.url);
           if (this.task === TASK.PR_SNAPSHOT)
-            await project.deleteArtifact(
+           /* await project.deleteArtifact(
               this.jfrogCredentials,
               this.currentVersion
-            );
+            );*/
           await project.publish();
         }
       }

--- a/tools/scripts/artifacts/artifacts-handler.ts
+++ b/tools/scripts/artifacts/artifacts-handler.ts
@@ -125,10 +125,10 @@ export class ArtifactsHandler {
           project.copyFossList();
           project.setVersionOrGeneratePackageJsonInDist(this.currentVersion, this.jfrogCredentials.url);
           if (this.task === TASK.PR_SNAPSHOT)
-           /* await project.deleteArtifact(
+            await project.deleteArtifact(
               this.jfrogCredentials,
               this.currentVersion
-            );*/
+            );
           await project.publish();
         }
       }

--- a/tools/scripts/artifacts/configuration.ts
+++ b/tools/scripts/artifacts/configuration.ts
@@ -1,3 +1,3 @@
 export function getNpmRegistryRepo(): string {
-  return process.env.NPM_REGISTRY || 'cplace-npm-local';
+  return process.env.NPM_REGISTRY !== undefined ? process.env.NPM_REGISTRY : 'cplace-npm-local';
 }

--- a/tools/scripts/artifacts/configuration.ts
+++ b/tools/scripts/artifacts/configuration.ts
@@ -1,3 +1,3 @@
-export function getNpmRegistryRepo(): string {
-  return process.env.NPM_REGISTRY !== undefined ? process.env.NPM_REGISTRY : 'cplace-npm-local';
+export function getJfrogUrl(): string {
+  return process.env.JFROG_URL !== undefined ? process.env.JFROG_URL : 'https://cplace.jfrog.io/artifactory/cplace-npm-local';
 }

--- a/tools/scripts/artifacts/configuration.ts
+++ b/tools/scripts/artifacts/configuration.ts
@@ -1,0 +1,3 @@
+export function getNpmRegistryRepo(): string {
+  return process.env.NPM_REGISTRY || 'cplace-npm-local';
+}

--- a/tools/scripts/artifacts/nx-project.test.ts
+++ b/tools/scripts/artifacts/nx-project.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import { NxProject, NxProjectKind } from './nx-project';
 import { globResult, packageJsonLib1 } from './test-data';
 import { Utils } from './utils';
+import { sep } from 'node:path';
 
 afterEach(() => {
   jest.resetAllMocks();
@@ -26,11 +27,11 @@ test('NxProject can provide jfrog Url', async () => {
     undefined,
     '@cplace-next'
   );
-  expect(nxProject.getJfrogUrl()).toBe(
-    'https://cplace.jfrog.io/ui/repos/tree/NpmInfo/cplace-npm-local/@cplace-next/test/-/@cplace-next/test-0.0.0.tgz'
+  expect(nxProject.getJfrogNpmArtifactUrl()).toBe(
+    'https://cplace.jfrog.io/artifactory/cplace-npm-local/@cplace-next/test/-/@cplace-next/test-0.0.0.tgz'
   );
   expect(nxProject.getMarkdownLink()).toBe(
-    '[@cplace-next/test@0.0.0](https://cplace.jfrog.io/ui/repos/tree/NpmInfo/cplace-npm-local/@cplace-next/test/-/@cplace-next/test-0.0.0.tgz)'
+    '[@cplace-next/test@0.0.0](https://cplace.jfrog.io/artifactory/cplace-npm-local/@cplace-next/test/-/@cplace-next/test-0.0.0.tgz)'
   );
 });
 
@@ -53,7 +54,7 @@ test('NxProject can find folder in src', async () => {
     undefined,
     '@cplace-next'
   );
-  expect(nxProject.getPathToProjectInSource()).toContain('libs/my-lib');
+  expect(nxProject.getPathToProjectInSource()).toContain('libs/my-lib'.replace(/\//g, sep));
 });
 
 test('NxProject can find folder in dist', async () => {
@@ -64,5 +65,5 @@ test('NxProject can find folder in dist', async () => {
     undefined,
     '@cplace-next'
   );
-  expect(nxProject.getPathToProjectInDist()).toContain('dist/apps/my-app');
+  expect(nxProject.getPathToProjectInDist()).toContain( 'dist/apps/my-app'.replace(/\//g, sep));
 });

--- a/tools/scripts/artifacts/nx-project.ts
+++ b/tools/scripts/artifacts/nx-project.ts
@@ -208,7 +208,7 @@ export class NxProject {
     this.npmrcContent = `${scope}:registry=${jfrogCredentials.url} \n`;
     this.npmrcContent =
       this.npmrcContent +
-      `${jfrogCredentials.getJfrogUrlNoHttp()}:_auth=${
+      `${jfrogCredentials.getJfrogUrlNoHttp()}:_authToken=${
         jfrogCredentials.base64Token
       } \n`;
     this.npmrcContent =

--- a/tools/scripts/artifacts/nx-project.ts
+++ b/tools/scripts/artifacts/nx-project.ts
@@ -196,7 +196,7 @@ export class NxProject {
           console.error(
             `An error ocurred while deleting the artifact: ${error}`
           );
-          reject();
+          resolve(res.statusCode);
         });
         resolve(res.statusCode);
       });

--- a/tools/scripts/artifacts/nx-project.ts
+++ b/tools/scripts/artifacts/nx-project.ts
@@ -182,7 +182,7 @@ export class NxProject {
       );
       const options = {
         hostname: 'cplace.jfrog.io',
-        path: `/artifactory/cplace-npm-local/${this.scope}/${this.name}/-/${
+        path: `/artifactory/cplace-assets-npm/${this.scope}/${this.name}/-/${
           this.scope
         }/${this.name}-${version.toString()}.tgz`,
         method: 'DELETE',

--- a/tools/scripts/artifacts/nx-project.ts
+++ b/tools/scripts/artifacts/nx-project.ts
@@ -8,6 +8,7 @@ import { Utils } from './utils';
 import { TASK } from './artifacts-handler';
 import { JfrogCredentials } from './jfrog-credentials';
 import { Version } from './version';
+import { getNpmRegistryRepo } from './configuration';
 
 interface PackageJson {
   author: string;
@@ -32,7 +33,7 @@ export enum VERSION_BUMP {
 
 export class NxProject {
   public static readonly REGISTRY_DOWNLOAD_URL =
-    'https://cplace.jfrog.io/ui/repos/tree/NpmInfo/cplace-assets-npm';
+    `https://cplace.jfrog.io/ui/repos/tree/NpmInfo/${getNpmRegistryRepo()}`;
   public static readonly PACKAGEJSON = 'package.json';
   public static readonly FOSS_LIST_FILENAME = 'cplace-foss-list.json';
   private _npmrcContent = '';
@@ -182,7 +183,7 @@ export class NxProject {
       );
       const options = {
         hostname: 'cplace.jfrog.io',
-        path: `/artifactory/cplace-assets-npm/${this.scope}/${this.name}/-/${
+        path: `/artifactory/${getNpmRegistryRepo()}/${this.scope}/${this.name}/-/${
           this.scope
         }/${this.name}-${version.toString()}.tgz`,
         method: 'DELETE',

--- a/tools/scripts/artifacts/nx-project.ts
+++ b/tools/scripts/artifacts/nx-project.ts
@@ -89,8 +89,6 @@ export class NxProject {
   }
 
   public getJfrogNpmArtifactUrl(): string {
-    //return `${NxProject.REGISTRY_DOWNLOAD_URL}/${this.scope}/${this.name}/-/${this.scope}/${this.name}-${this.version.toString()}.tgz`;
-    // https://cplace.jfrog.io/artifactory/cplace-assets-npm/@cplace-legacy-fe-assets/cf-legacy-fe-dependencies/-/@cplace-legacy-fe-assets/cf-legacy-fe-dependencies-0.0.2.tgz
     return getJfrogUrl() + `/${this.scope}/${this.name}/-/${this.scope}/${this.name}-${this.version.toString()}.tgz`;
   }
 

--- a/tools/scripts/artifacts/nx-project.ts
+++ b/tools/scripts/artifacts/nx-project.ts
@@ -196,7 +196,7 @@ export class NxProject {
           console.error(
             `An error ocurred while deleting the artifact: ${error}`
           );
-          resolve(res.statusCode);
+          reject();
         });
         resolve(res.statusCode);
       });

--- a/tools/scripts/artifacts/nx-project.ts
+++ b/tools/scripts/artifacts/nx-project.ts
@@ -32,7 +32,7 @@ export enum VERSION_BUMP {
 
 export class NxProject {
   public static readonly REGISTRY_DOWNLOAD_URL =
-    'https://cplace.jfrog.io/ui/repos/tree/NpmInfo/cplace-npm-local';
+    'https://cplace.jfrog.io/ui/repos/tree/NpmInfo/cplace-assets-npm';
   public static readonly PACKAGEJSON = 'package.json';
   public static readonly FOSS_LIST_FILENAME = 'cplace-foss-list.json';
   private _npmrcContent = '';

--- a/tools/scripts/artifacts/nx-project.ts
+++ b/tools/scripts/artifacts/nx-project.ts
@@ -208,7 +208,7 @@ export class NxProject {
     this.npmrcContent = `${scope}:registry=${jfrogCredentials.url} \n`;
     this.npmrcContent =
       this.npmrcContent +
-      `${jfrogCredentials.getJfrogUrlNoHttp()}:_authToken=${
+      `${jfrogCredentials.getJfrogUrlNoHttp()}:_auth=${
         jfrogCredentials.base64Token
       } \n`;
     this.npmrcContent =

--- a/tools/scripts/artifacts/utils.test.ts
+++ b/tools/scripts/artifacts/utils.test.ts
@@ -40,7 +40,7 @@ const rootDir = child_process
 
 beforeEach(() => {
   const mockedDate = new Date(2023, 0, 1);
-  jest.useFakeTimers('modern');
+  jest.useFakeTimers();
   jest.setSystemTime(mockedDate);
   jest.spyOn(Utils, 'globProjectJSON').mockReturnValue(globResult);
 });


### PR DESCRIPTION
Resolves [PFM-TASK-5418](https://base.cplace.io/pages/lsmobmzjn0hkhcjthdjlu91a0/PFM-TASK-5418-Rework-hard-coded-jfrog-url-in-the-delete-pr-snapshot-workflow)

`changelog: Frontend-Core: [PFM-TASK-5418] Improvement: Rework hard coded jfrog url in the delete pr snapshot workflow [PR github-actions#76]`

**Developer Checklist:**

- [ ] Updated documentation if needed
- [x] Created Changelog according
  to [Guidelines](https://docs.cplace.io/frontend-applications/22-3/guides/pr-guideline/)
