### PR TITLE
PFM-ISSUE-28695 - Unlink PR Snapshot link from the GHA Workflow

### DIFF
--- a/.github/workflows/fe-pr-snapshot.yml
+++ b/.github/workflows/fe-pr-snapshot.yml
@@ -56,8 +56,9 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
 
       - name: comment published Artifacts on PR
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filePath: githubCommentsForPR.txt
+          comment-tag: published-artifacts

--- a/.github/workflows/fe-pr-snapshot.yml
+++ b/.github/workflows/fe-pr-snapshot.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm ci
 
       - name: Build and Push to Jfrog NPM Registry
-        uses: collaborationFactory/github-actions/.github/actions/artifacts@master
+        uses: collaborationFactory/github-actions/.github/actions/artifacts@fix/PFM-ISSUE-28695-Unlink-PR-Snapshot-link-from-the-GHA-Workflow
         env:
           JFROG_BASE64_TOKEN: ${{ secrets.JFROG_BASE64_TOKEN }}
           JFROG_URL: ${{ secrets.JFROG_URL }}

--- a/.github/workflows/fe-pr-snapshot.yml
+++ b/.github/workflows/fe-pr-snapshot.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm ci
 
       - name: Build and Push to Jfrog NPM Registry
-        uses: collaborationFactory/github-actions/.github/actions/artifacts@fix/PFM-ISSUE-28695-Unlink-PR-Snapshot-link-from-the-GHA-Workflow
+        uses: collaborationFactory/github-actions/.github/actions/artifacts@master
         env:
           JFROG_BASE64_TOKEN: ${{ secrets.JFROG_BASE64_TOKEN }}
           JFROG_URL: ${{ secrets.JFROG_URL }}

--- a/.github/workflows/fe-pr-snapshot.yml
+++ b/.github/workflows/fe-pr-snapshot.yml
@@ -60,5 +60,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          filePath: githubCommentsForPR.txt
+          file-path: githubCommentsForPR.txt
           comment-tag: published-artifacts

--- a/tools/scripts/artifacts/nx-project.ts
+++ b/tools/scripts/artifacts/nx-project.ts
@@ -94,7 +94,7 @@ export class NxProject {
   }
 
   public getMarkdownLink(): string {
-    return `${this.version.toString()}`;
+    return `${this.getPackageInstallPath()}`;
   }
 
   public async publish() {

--- a/tools/scripts/artifacts/nx-project.ts
+++ b/tools/scripts/artifacts/nx-project.ts
@@ -89,6 +89,9 @@ export class NxProject {
     return `${this.scope}/${this.name}@${this.version.toString()}`;
   }
 
+  /**
+   * we are no longer using this method and can be removed along with the unit tests REF:PFM-ISSUE-28695
+   */
   public getJfrogNpmArtifactUrl(): string {
     return getJfrogUrl() + `/${this.scope}/${this.name}/-/${this.scope}/${this.name}-${this.version.toString()}.tgz`;
   }
@@ -110,7 +113,7 @@ export class NxProject {
         );
       } catch (error: any) {
         console.error(
-          `An error ocurred while publishing the artifact: ${error}`
+          `An error occurred while publishing the artifact: ${error}`
         );
         if (error.status !== 0) process.exit(1);
       }

--- a/tools/scripts/artifacts/nx-project.ts
+++ b/tools/scripts/artifacts/nx-project.ts
@@ -94,7 +94,7 @@ export class NxProject {
   }
 
   public getMarkdownLink(): string {
-    return `[${this.getPackageInstallPath()}](${this.getJfrogNpmArtifactUrl()})`;
+    return `${this.version.toString()}`;
   }
 
   public async publish() {


### PR DESCRIPTION
Resolves [PFM-ISSUE-28695](https://base.cplace.io/pages/4x9gudqe6afubb0486lbfcmpp/PFM-ISSUE-28695-Unlink-PR-Snapshot-link-from-the-GHA-Workflow#id_wsrqdlqi9cus7fztqfsfa3gnz=newOverview)

`changelog: Frontend-Core: [PFM-ISSUE-28695] Fix: GHA action updated to the v3 and removed link for comments[PR github-actions#80]`


**Developer Checklist:**

- [ ] Updated documentation if needed
- [x] Created Changelog according
  to [Guidelines](https://docs.cplace.io/frontend-applications/22-3/guides/pr-guideline/)
