### PR TITLE
PFM-ISSUE-29885:Update the timestamp in github comments from UTC to CET

### DIFF
--- a/tools/scripts/artifacts/utils.ts
+++ b/tools/scripts/artifacts/utils.ts
@@ -314,7 +314,6 @@ export class Utils {
     }
   }
 
-
   public static parseScopeFromPackageJson(): string {
     const gitRootDir = Utils.getRootDir();
     const pathToRootPackageJson = path.join(gitRootDir, NxProject.PACKAGEJSON);

--- a/tools/scripts/artifacts/utils.ts
+++ b/tools/scripts/artifacts/utils.ts
@@ -287,6 +287,14 @@ export class Utils {
 
   public static writePublishedProjectToGithubCommentsFile(message: string) {
     const gitHubCommentsFile = Utils.getGitHubCommentsFile();
+    const currentDate = new Date();
+    const dateString = currentDate.toLocaleDateString("en-GB", {
+      timeZone: "Europe/Berlin",
+    });
+    const timeString = currentDate.toLocaleTimeString("en-GB", {
+      timeZone: "Europe/Berlin",
+    });
+
     if (!fs.existsSync(gitHubCommentsFile)) {
       fs.writeFileSync(gitHubCommentsFile, `${message}\n`);
     } else {
@@ -299,12 +307,13 @@ export class Utils {
         fs.writeFileSync(
           gitHubCommentsFile,
           `:tada: Snapshots of the following projects have been published:
-                        Last updated: ${new Date().toLocaleDateString()} ${new Date().toLocaleTimeString()} \n`
+                        Last updated: ${dateString} ${timeString} (CET/CEST) \n`
         );
       }
       fs.appendFileSync(gitHubCommentsFile, `${message}\n`);
     }
   }
+
 
   public static parseScopeFromPackageJson(): string {
     const gitRootDir = Utils.getRootDir();


### PR DESCRIPTION
Resolves [PFM-ISSUE-29885](https://base.cplace.io/pages/hn8sb7o3vk6usri1pl27l08dq/PFM-ISSUE-29885-Update-the-timestamp-in-github-comments-from-UTC-to-CET#id_wsrqdlqi9cus7fztqfsfa3gnz=newOverview)

`changelog: Frontend-Core: [PFM-ISSUE-29885] Fix: Updated the timestamp of github comments to CET [PR github-actions#91]`

**Developer Checklist:**

- [ ] Updated documentation if needed
- [x] Created Changelog according
  to [Guidelines](https://docs.cplace.io/frontend-applications/22-3/guides/pr-guideline/)
