### PR TITLE
PFM-ISSUE-30340 - GitHub Action Links Point to Wrong Repository in frontend upmerge slack channel

### DIFF
--- a/tools/scripts/upmerge/upmerge.test.ts
+++ b/tools/scripts/upmerge/upmerge.test.ts
@@ -29,3 +29,15 @@ test('can detect no upmerge is needed', async () => {
     'Merging upmerge-CscNaE/release/23.4 into origin/release/24.1\n');
   expect(new UpmergeHandler().isUpmergeNeeded().message).toBe('');
 });
+
+test('returns error message with correct repo name in link', async () => {
+  jest.spyOn(child_process, 'execSync')
+    .mockReturnValueOnce('https://github.com/collaborationFactory/cplace-paw-fe.git') // repo URL
+    .mockImplementationOnce(() => { throw new Error('cli failed'); }); // simulate error
+
+  process.env.GITHUB_RUN_ID = '123456';
+  const result = new UpmergeHandler().isUpmergeNeeded();
+  expect(result.message).toBe(
+    'There was an error running cplace-cli in repo https://github.com/collaborationFactory/cplace-paw-fe.git:\n\nhttps://github.com/collaborationFactory/cplace-paw-fe/actions/runs/123456'
+  );
+});

--- a/tools/scripts/upmerge/upmerge.ts
+++ b/tools/scripts/upmerge/upmerge.ts
@@ -23,7 +23,9 @@ export class UpmergeHandler {
       cliResult = execSync('cplace-cli flow --upmerge --release 5.17 --no-push --show-files').toString().split('\n')
       console.log('cliResult: ', cliResult);
     } catch (error) {
-      const linkToAction = `https://github.com/collaborationFactory/cplace-fe/actions/runs/${process.env.GITHUB_RUN_ID}`;
+      const repoNameMatch = repo.match(/github\.com\/[^\/]+\/([^\/\.]+)(\.git)?$/);
+      const repoName = repoNameMatch ? repoNameMatch[1] : 'cplace-fe';
+      const linkToAction = `https://github.com/collaborationFactory/${repoName}/actions/runs/${process.env.GITHUB_RUN_ID}`;
       return {
         message: `There was an error running cplace-cli in repo ${repo}:\n\n${linkToAction}`,
         threadMessage: error.message


### PR DESCRIPTION
Resolves [PFM-ISSUE-30340](https://base.cplace.io/pages/pzz6y0eq3fhc5bpv2ajqebhrt/PFM-ISSUE-30340-GitHub-Action-Links-Point-to-Wrong-Repository-in-frontend-upmerge-slack-channel#id_wsrqdlqi9cus7fztqfsfa3gnz=newOverview)

`changelog: Frontend-Core: [PFM-ISSUE-30340] Fix: Corrected the hardcoded cplace-fe repo name [PR github-actions#PR-number]`

**Developer Checklist:**

- [ ] Updated documentation if needed
- [ ] Created Changelog according
  to [Guidelines](https://docs.cplace.io/frontend-applications/22-3/guides/pr-guideline/)
