### PR TITLE
PFM-ISSUE-30550 - Cypress E2E Tests Fail Due to Invalid --base Parameter in GitHub Actions

### DIFF
--- a/.github/workflows/fe-e2e.yml
+++ b/.github/workflows/fe-e2e.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Affected Regression Tests
         id: regressionTests
         continue-on-error: true
-        uses: collaborationFactory/github-actions/.github/actions/run-many@fix/PFM-ISSUE-30550-Cypress-E2E-Tests-Fail-Due-to-Invalid-base
+        uses: collaborationFactory/github-actions/.github/actions/run-many@release/25.3
         with:
           target: ${{ matrix.target }}
           jobIndex: ${{ matrix.jobIndex }}

--- a/tools/scripts/run-many/run-many.ts
+++ b/tools/scripts/run-many/run-many.ts
@@ -10,7 +10,6 @@ function getE2ECommand(command: string, base: string): string {
 function runCommand(command: string): void {
   if (command.includes('--targets=e2e')) {
     const commandArr = command.split(' ');
-    console.log(commandArr);
     command = commandArr.filter(c => !c.includes('--base=')).join(' ');
   }
   core.info(`Running > ${command}`);


### PR DESCRIPTION
Resolves [PFM-ISSUE-30550](https://base.cplace.io/pages/ec6loyf5u8sbqsqvday8yv9l4/PFM-ISSUE-30550-Cypress-E2E-Tests-Fail-Due-to-Invalid-base-Parameter-in-GitHub-Actions#id_wsrqdlqi9cus7fztqfsfa3gnz=cf.cplace.cfactoryPlatform.qualityAssurance)

`changelog: Frontend-Core: [PFM-ISSUE-30550] Fix: Cypress E2E Tests Fail Due to Invalid --base Parameter in GitHub Actions [PR github-actions#98]`

**Developer Checklist:**

- [ ] Updated documentation if needed
- [x] Created Changelog according
  to [Guidelines](https://docs.cplace.io/frontend-applications/22-3/guides/pr-guideline/)
