### PR TITLE
PFM-ISSUE-33179 Frontend Licenses Library Action Does Not Block PRs Despite Missing Licenses

### DIFF
--- a/.github/workflows/fe-licenses.yml
+++ b/.github/workflows/fe-licenses.yml
@@ -58,13 +58,5 @@ jobs:
         run: node node_modules/@cplace-next/cf-frontend-licenses/main.js check ${{ inputs.FOSS_DIST }} ${{ inputs.CUSTOM_LICENSES_JSON }}
 
       - name: Run Diff
-        continue-on-error: true
+        id: diffFoss
         run: diff -a --suppress-common-lines -y ./cplace-foss-list.json ${{ inputs.FOSS_DIST }}/cplace-foss-list.json
-
-      - name: Read fossTmp
-        id: readFossTmp
-        run: echo "foss_status=$(cat ${{ inputs.FOSS_DIST }}/fossTmp)" >> $GITHUB_OUTPUT
-
-      - name: Check fossTmp
-        if: steps.readFossTmp.outputs.foss_status == '1'
-        run: exit 1

--- a/.github/workflows/fe-licenses.yml
+++ b/.github/workflows/fe-licenses.yml
@@ -56,13 +56,15 @@ jobs:
         run: node node_modules/@cplace-next/cf-frontend-licenses/main.js check ${{ inputs.FOSS_DIST }} ${{ inputs.CUSTOM_LICENSES_JSON }}
 
       - name: Run Diff
+        if: steps.localLicenseChecker.outcome == 'failure'
         continue-on-error: true
         run: diff -a --suppress-common-lines -y ./cplace-foss-list.json ${{ inputs.FOSS_DIST }}/cplace-foss-list.json
 
       - name: Read fossTmp
         id: readFossTmp
-        run: echo "{foss_status}={$(cat ${{ inputs.FOSS_DIST }}/fossTmp)}" >> $GITHUB_OUTPUT
+        if: steps.localLicenseChecker.outcome == 'failure'
+        run: echo "foss_status=$(cat ${{ inputs.FOSS_DIST }}/fossTmp)" >> $GITHUB_OUTPUT
 
       - name: Check fossTmp
-        if: steps.readFossTmp.outputs.foss_status == '1'
+        if: steps.localLicenseChecker.outcome == 'failure' || steps.readFossTmp.outputs.foss_status == '1'
         run: exit 1

--- a/.github/workflows/fe-licenses.yml
+++ b/.github/workflows/fe-licenses.yml
@@ -48,23 +48,23 @@ jobs:
 
       - name: Check Licenses Local
         id: localLicenseChecker
+        if: github.event.repository.name == 'cplace-fe'
         continue-on-error: true
         run: npx nx run cf-frontend-licenses:check
 
       - name: Check Licenses Remote
-        if: steps.localLicenseChecker.outcome == 'failure'
+        if: github.event.repository.name != 'cplace-fe'
+        continue-on-error: true
         run: node node_modules/@cplace-next/cf-frontend-licenses/main.js check ${{ inputs.FOSS_DIST }} ${{ inputs.CUSTOM_LICENSES_JSON }}
 
       - name: Run Diff
-        if: steps.localLicenseChecker.outcome == 'failure'
         continue-on-error: true
         run: diff -a --suppress-common-lines -y ./cplace-foss-list.json ${{ inputs.FOSS_DIST }}/cplace-foss-list.json
 
       - name: Read fossTmp
         id: readFossTmp
-        if: steps.localLicenseChecker.outcome == 'failure'
         run: echo "foss_status=$(cat ${{ inputs.FOSS_DIST }}/fossTmp)" >> $GITHUB_OUTPUT
 
       - name: Check fossTmp
-        if: steps.localLicenseChecker.outcome == 'failure' || steps.readFossTmp.outputs.foss_status == '1'
+        if: steps.readFossTmp.outputs.foss_status == '1'
         run: exit 1


### PR DESCRIPTION
Resolves [PFM-ISSUE-33179](https://base.cplace.io/pages/amvch3clzsu80sx2qqfro81ur/PFM-ISSUE-33179-Frontend-Licenses-Library-Action-Does-Not-Block-PRs-Despite-Missing-Licenses#id_wsrqdlqi9cus7fztqfsfa3gnz=newOverview)

`changelog: Platform Experience: [PFM-ISSUE-33179] Fix: Frontend Licenses Library Action Does Not Block PRs Despite Missing Licenses [PR github-actions#128]`

**Developer Checklist:**

- [ ] Updated documentation if needed
- [x] Created Changelog according
      to [Guidelines](https://docs.cplace.io/frontend-applications/22-3/guides/pr-guideline/)
