### PR TITLE
fix(dependabot): ignore collaborationFactory/* actions on all branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
   # Default branch (master)
   - package-ecosystem: "github-actions"
     directory: "/"
+    ignore:
+      - dependency-name: 'collaborationFactory/*'
     schedule:
       interval: "weekly"
       day: "monday"
@@ -19,6 +21,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "release/25.2"
+    ignore:
+      - dependency-name: 'collaborationFactory/*'
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -34,6 +38,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "release/25.3"
+    ignore:
+      - dependency-name: 'collaborationFactory/*'
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -49,6 +55,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "release/25.4"
+    ignore:
+      - dependency-name: 'collaborationFactory/*'
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -64,6 +72,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "release/26.1"
+    ignore:
+      - dependency-name: 'collaborationFactory/*'
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -79,6 +89,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "release/26.2"
+    ignore:
+      - dependency-name: 'collaborationFactory/*'
     schedule:
       interval: "weekly"
       day: "tuesday"


### PR DESCRIPTION
## Summary
- Add `ignore` rule for `collaborationFactory/*` to all 6 dependabot update blocks (master + release/25.2 through release/26.2)
- Prevents Dependabot from opening PRs for internal `collaborationFactory/` GitHub Actions

## Test plan
- [ ] Verify no new Dependabot PRs are opened for `collaborationFactory/*` actions after merge